### PR TITLE
Use UTF-8 charset to display Umlauts (ä,ö,ü) in German translation

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -8,14 +8,15 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2012-09-15 20:37+0200\n"
-"PO-Revision-Date: 2012-12-18 21:50+0100\n"
-"Last-Translator: Marco DallaG <marco.dallagiacoma@gmail.com>\n"
-"Language-Team: German\n"
-"Language: de\n"
+"PO-Revision-Date: 2020-11-18 22:01+0100\n"
+"Last-Translator: Philipp Kiemle <philipp.kiemle@gmail.com>\n"
+"Language-Team: German - Germany <philipp.kiemle@gmail.com>\n"
+"Language: de_DE\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=ASCII\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Gtranslator 3.38.0\n"
 
 #: extension.js:16
 #, c-format
@@ -24,7 +25,7 @@ msgstr "%0 Uhr"
 
 #: extension.js:17
 msgid "five past %0"
-msgstr "F\374nf nach %0"
+msgstr "Fünf nach %0"
 
 #: extension.js:18
 msgid "ten past %0"
@@ -40,7 +41,7 @@ msgstr "Zwanzig nach %0"
 
 #: extension.js:21
 msgid "twenty five past %0"
-msgstr "F\374nf vor halb %1"
+msgstr "Fünf vor halb %0"
 
 #: extension.js:22
 msgid "half past %0"
@@ -48,7 +49,7 @@ msgstr "Halb %1"
 
 #: extension.js:23
 msgid "twenty five to %1"
-msgstr "F\374nf nach halb %1"
+msgstr "Fünf nach halb %1"
 
 #: extension.js:24
 msgid "twenty to %1"
@@ -64,7 +65,7 @@ msgstr "Zehn vor %1"
 
 #: extension.js:27
 msgid "five to %1"
-msgstr "F\374nf vor %1"
+msgstr "Fünf vor %1"
 
 #: extension.js:28
 msgid "%1 o'clock"
@@ -72,7 +73,7 @@ msgstr "%1 Uhr"
 
 #: extension.js:32 extension.js:44
 msgid "twelve"
-msgstr "Zw\366lf"
+msgstr "zöwlf"
 
 #: extension.js:33
 msgid "one"
@@ -92,7 +93,7 @@ msgstr "vier"
 
 #: extension.js:37
 msgid "five"
-msgstr "f\374nf"
+msgstr "fünf"
 
 #: extension.js:38
 msgid "six"

--- a/po/de.po
+++ b/po/de.po
@@ -73,7 +73,7 @@ msgstr "%1 Uhr"
 
 #: extension.js:32 extension.js:44
 msgid "twelve"
-msgstr "zöwlf"
+msgstr "zwölf"
 
 #: extension.js:33
 msgid "one"

--- a/po/fr.po
+++ b/po/fr.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: French\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=ASCII\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 

--- a/po/it.po
+++ b/po/it.po
@@ -14,7 +14,7 @@ msgstr ""
 "Language-Team: Italian\n"
 "Language: it\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=ISO-8859-1\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 

--- a/po/messages.pot
+++ b/po/messages.pot
@@ -14,7 +14,7 @@ msgstr ""
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
 #: extension.js:16


### PR DESCRIPTION
I saw that the `.po` file was initially set to encode in ASCII, which resulted in problems rendering the `ü` in `fünf`. I've set all `.po` files to use the UTF-8 encoding now.