### PR TITLE
Automatically add translatable Strings to the .pot file

### DIFF
--- a/lib/fuzzyTime.js
+++ b/lib/fuzzyTime.js
@@ -1,34 +1,37 @@
+/* eslint-disable no-undef */
+const _ = imports.gettext.domain('Fuzzy_Clock@dallagi').gettext;
+/* eslint-enable no-undef */
 
 const hoursList = [
-  "%0 o'clock",
-  'five past %0',
-  'ten past %0',
-  'quarter past %0',
-  'twenty past %0',
-  'twenty five past %0',
-  'half past %0',
-  'twenty five to %1',
-  'twenty to %1',
-  'quarter to %1',
-  'ten to %1',
-  'five to %1',
-  "%1 o'clock"
+  _("%0 o'clock"),
+  _('five past %0'),
+  _('ten past %0'),
+  _('quarter past %0'),
+  _('twenty past %0'),
+  _('twenty five past %0'),
+  _('half past %0'),
+  _('twenty five to %1'),
+  _('twenty to %1'),
+  _('quarter to %1'),
+  _('ten to %1'),
+  _('five to %1'),
+  _("%1 o'clock")
 ]
 
 const hourNames = [
-  'twelve',
-  'one',
-  'two',
-  'three',
-  'four',
-  'five',
-  'six',
-  'seven',
-  'eight',
-  'nine',
-  'ten',
-  'eleven',
-  'twelve'
+  _('twelve'),
+  _('one'),
+  _('two'),
+  _('three'),
+  _('four'),
+  _('five'),
+  _('six'),
+  _('seven'),
+  _('eight'),
+  _('nine'),
+  _('ten'),
+  _('eleven'),
+  _('twelve')
 ]
 
 var FuzzyTime = class {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
         "lint:fix": "standard --fix",
         "logs": "journalctl /usr/bin/gnome-shell -f -o cat",
         "build": "scripts/build.sh",
+        "update-po" : "scripts/update-po.sh",
         "test": "mocha"
     },
     "devDependencies": {

--- a/po/de_DE.po
+++ b/po/de_DE.po
@@ -1,120 +1,121 @@
-# German translations for PACKAGE package.
-# Copyright (C) 2012 THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
+# German translation for Fuzzy Clock.
+# Deutsche Übersetzung für Fuzzy Clock.
+# Copyright (C) 2020 Marco Dallagiacoma
+# This file is distributed under the same license as the Fuzzy Clock package.
 # Marco DallaG <marco.dallagiacoma@gmail.com>, 2012.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
+"Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2012-09-15 20:37+0200\n"
-"PO-Revision-Date: 2020-11-18 22:01+0100\n"
+"POT-Creation-Date: 2020-11-26 11:26+0100\n"
+"PO-Revision-Date: 2020-11-26 11:26+0100\n"
 "Last-Translator: Philipp Kiemle <philipp.kiemle@gmail.com>\n"
-"Language-Team: German - Germany <philipp.kiemle@gmail.com>\n"
+"Language-Team: German - Germany\n"
 "Language: de_DE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Gtranslator 3.38.0\n"
+"X-Generator: Poedit 2.4.1\n"
 
-#: extension.js:16
-#, c-format
+#: ../lib/fuzzyTime.js:6
+#, javascript-format
 msgid "%0 o'clock"
 msgstr "%0 Uhr"
 
-#: extension.js:17
+#: ../lib/fuzzyTime.js:7
 msgid "five past %0"
 msgstr "Fünf nach %0"
 
-#: extension.js:18
+#: ../lib/fuzzyTime.js:8
 msgid "ten past %0"
 msgstr "Zehn nach %0"
 
-#: extension.js:19
+#: ../lib/fuzzyTime.js:9
 msgid "quarter past %0"
 msgstr "Viertel nach %0"
 
-#: extension.js:20
+#: ../lib/fuzzyTime.js:10
 msgid "twenty past %0"
 msgstr "Zwanzig nach %0"
 
-#: extension.js:21
+#: ../lib/fuzzyTime.js:11
 msgid "twenty five past %0"
-msgstr "Fünf vor halb %0"
+msgstr "Fünf vor halb %1"
 
-#: extension.js:22
+#: ../lib/fuzzyTime.js:12
 msgid "half past %0"
 msgstr "Halb %1"
 
-#: extension.js:23
+#: ../lib/fuzzyTime.js:13
 msgid "twenty five to %1"
 msgstr "Fünf nach halb %1"
 
-#: extension.js:24
+#: ../lib/fuzzyTime.js:14
 msgid "twenty to %1"
 msgstr "Zwanzig vor %1"
 
-#: extension.js:25
+#: ../lib/fuzzyTime.js:15
 msgid "quarter to %1"
 msgstr "Viertel vor %1"
 
-#: extension.js:26
+#: ../lib/fuzzyTime.js:16
 msgid "ten to %1"
 msgstr "Zehn vor %1"
 
-#: extension.js:27
+#: ../lib/fuzzyTime.js:17
 msgid "five to %1"
 msgstr "Fünf vor %1"
 
-#: extension.js:28
+#: ../lib/fuzzyTime.js:18
 msgid "%1 o'clock"
 msgstr "%1 Uhr"
 
-#: extension.js:32 extension.js:44
+#: ../lib/fuzzyTime.js:22 ../lib/fuzzyTime.js:34
 msgid "twelve"
 msgstr "zwölf"
 
-#: extension.js:33
+#: ../lib/fuzzyTime.js:23
 msgid "one"
 msgstr "eins"
 
-#: extension.js:34
+#: ../lib/fuzzyTime.js:24
 msgid "two"
 msgstr "zwei"
 
-#: extension.js:35
+#: ../lib/fuzzyTime.js:25
 msgid "three"
 msgstr "drei"
 
-#: extension.js:36
+#: ../lib/fuzzyTime.js:26
 msgid "four"
 msgstr "vier"
 
-#: extension.js:37
+#: ../lib/fuzzyTime.js:27
 msgid "five"
 msgstr "fünf"
 
-#: extension.js:38
+#: ../lib/fuzzyTime.js:28
 msgid "six"
 msgstr "sechs"
 
-#: extension.js:39
+#: ../lib/fuzzyTime.js:29
 msgid "seven"
 msgstr "sieben"
 
-#: extension.js:40
+#: ../lib/fuzzyTime.js:30
 msgid "eight"
 msgstr "acht"
 
-#: extension.js:41
+#: ../lib/fuzzyTime.js:31
 msgid "nine"
 msgstr "neun"
 
-#: extension.js:42
+#: ../lib/fuzzyTime.js:32
 msgid "ten"
 msgstr "zehn"
 
-#: extension.js:43
+#: ../lib/fuzzyTime.js:33
 msgid "eleven"
 msgstr "elf"

--- a/po/en_US.po
+++ b/po/en_US.po
@@ -1,119 +1,119 @@
-# English translations for Fuzzy Clock package.
-# Copyright (C) 2012 THE Fuzzy Clock'S COPYRIGHT HOLDER
+# English translations for Fuzzy Clock.
+# Copyright (C) 2020 Marco Dallagiacoma
 # This file is distributed under the same license as the Fuzzy Clock package.
 # Marco Dallagiacoma <marco.dallagiacoma@gmail.com>, 2012.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
+"Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2012-09-15 20:37+0200\n"
-"PO-Revision-Date: 2012-09-15 20:39+0200\n"
-"Last-Translator: Marco DallaG <marco.dallagiacoma@gmail.com>\n"
-"Language-Team: English\n"
+"POT-Creation-Date: 2020-11-26 11:26+0100\n"
+"PO-Revision-Date: 2020-11-26 11:26+0100\n"
+"Last-Translator: Philipp Kiemle <philipp.kiemle@gmail.com>\n"
+"Language-Team: English - US\n"
 "Language: en_US\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: extension.js:16
-#, c-format
+#: ../lib/fuzzyTime.js:6
+#, javascript-format
 msgid "%0 o'clock"
 msgstr "%0 o'clock"
 
-#: extension.js:17
+#: ../lib/fuzzyTime.js:7
 msgid "five past %0"
 msgstr "five past %0"
 
-#: extension.js:18
+#: ../lib/fuzzyTime.js:8
 msgid "ten past %0"
 msgstr "ten past %0"
 
-#: extension.js:19
+#: ../lib/fuzzyTime.js:9
 msgid "quarter past %0"
 msgstr "quarter past %0"
 
-#: extension.js:20
+#: ../lib/fuzzyTime.js:10
 msgid "twenty past %0"
 msgstr "twenty past %0"
 
-#: extension.js:21
+#: ../lib/fuzzyTime.js:11
 msgid "twenty five past %0"
 msgstr "twenty five past %0"
 
-#: extension.js:22
+#: ../lib/fuzzyTime.js:12
 msgid "half past %0"
 msgstr "half past %0"
 
-#: extension.js:23
+#: ../lib/fuzzyTime.js:13
 msgid "twenty five to %1"
 msgstr "twenty five to %1"
 
-#: extension.js:24
+#: ../lib/fuzzyTime.js:14
 msgid "twenty to %1"
 msgstr "twenty to %1"
 
-#: extension.js:25
+#: ../lib/fuzzyTime.js:15
 msgid "quarter to %1"
 msgstr "quarter to %1"
 
-#: extension.js:26
+#: ../lib/fuzzyTime.js:16
 msgid "ten to %1"
 msgstr "ten to %1"
 
-#: extension.js:27
+#: ../lib/fuzzyTime.js:17
 msgid "five to %1"
 msgstr "five to %1"
 
-#: extension.js:28
+#: ../lib/fuzzyTime.js:18
 msgid "%1 o'clock"
 msgstr "%1 o'clock"
 
-#: extension.js:32 extension.js:44
+#: ../lib/fuzzyTime.js:22 ../lib/fuzzyTime.js:34
 msgid "twelve"
 msgstr "twelve"
 
-#: extension.js:33
+#: ../lib/fuzzyTime.js:23
 msgid "one"
 msgstr "one"
 
-#: extension.js:34
+#: ../lib/fuzzyTime.js:24
 msgid "two"
 msgstr "two"
 
-#: extension.js:35
+#: ../lib/fuzzyTime.js:25
 msgid "three"
 msgstr "three"
 
-#: extension.js:36
+#: ../lib/fuzzyTime.js:26
 msgid "four"
 msgstr "four"
 
-#: extension.js:37
+#: ../lib/fuzzyTime.js:27
 msgid "five"
 msgstr "five"
 
-#: extension.js:38
+#: ../lib/fuzzyTime.js:28
 msgid "six"
 msgstr "six"
 
-#: extension.js:39
+#: ../lib/fuzzyTime.js:29
 msgid "seven"
 msgstr "seven"
 
-#: extension.js:40
+#: ../lib/fuzzyTime.js:30
 msgid "eight"
 msgstr "eight"
 
-#: extension.js:41
+#: ../lib/fuzzyTime.js:31
 msgid "nine"
 msgstr "nine"
 
-#: extension.js:42
+#: ../lib/fuzzyTime.js:32
 msgid "ten"
 msgstr "ten"
 
-#: extension.js:43
+#: ../lib/fuzzyTime.js:33
 msgid "eleven"
 msgstr "eleven"

--- a/po/eo_EO.po
+++ b/po/eo_EO.po
@@ -1,119 +1,119 @@
 # Esperanto translations for Fuzzy Clock package.
-# Copyright (C) 2012 Marco Dallagiacoma
+# Copyright (C) 2020 Marco Dallagiacoma
 # This file is distributed under the same license as the Fuzzy Clock package.
 # Marco Dallagiacoma <marco.dallagiacoma@gmail.com>, 2012.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
+"Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2012-09-15 20:37+0200\n"
-"PO-Revision-Date: 2012-09-15 20:42+0200\n"
-"Last-Translator: Marco DallaG <marco.dallagiacoma@gmail.com>\n"
-"Language-Team: Esperanto\n"
+"POT-Creation-Date: 2020-11-26 11:26+0100\n"
+"PO-Revision-Date: 2020-11-26 11:26+0100\n"
+"Last-Translator: Philipp Kiemle <philipp.kiemle@gmail.com>\n"
+"Language-Team: Esperanto - Esperanto\n"
 "Language: eo_EO\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: extension.js:16
-#, c-format
+#: ../lib/fuzzyTime.js:6
+#, javascript-format
 msgid "%0 o'clock"
 msgstr "%0"
 
-#: extension.js:17
+#: ../lib/fuzzyTime.js:7
 msgid "five past %0"
 msgstr "%0 kaj kvin minutoj"
 
-#: extension.js:18
+#: ../lib/fuzzyTime.js:8
 msgid "ten past %0"
 msgstr "%0 kaj dek minutoj"
 
-#: extension.js:19
+#: ../lib/fuzzyTime.js:9
 msgid "quarter past %0"
 msgstr "%0 kaj kvarono"
 
-#: extension.js:20
+#: ../lib/fuzzyTime.js:10
 msgid "twenty past %0"
 msgstr "%0 kaj dudek minutoj"
 
-#: extension.js:21
+#: ../lib/fuzzyTime.js:11
 msgid "twenty five past %0"
 msgstr "%0 kaj dudek kvin minutoj"
 
-#: extension.js:22
+#: ../lib/fuzzyTime.js:12
 msgid "half past %0"
 msgstr "%0 kaj duono"
 
-#: extension.js:23
+#: ../lib/fuzzyTime.js:13
 msgid "twenty five to %1"
 msgstr "%0 kaj tridek kvin minutoj"
 
-#: extension.js:24
+#: ../lib/fuzzyTime.js:14
 msgid "twenty to %1"
 msgstr "%0 kaj kvardek minutoj"
 
-#: extension.js:25
+#: ../lib/fuzzyTime.js:15
 msgid "quarter to %1"
 msgstr "%0 kaj tri kvaronoj"
 
-#: extension.js:26
+#: ../lib/fuzzyTime.js:16
 msgid "ten to %1"
 msgstr "%0 kaj kvindek minutoj"
 
-#: extension.js:27
+#: ../lib/fuzzyTime.js:17
 msgid "five to %1"
 msgstr "%0 kaj kvindek kvin minutoj"
 
-#: extension.js:28
+#: ../lib/fuzzyTime.js:18
 msgid "%1 o'clock"
 msgstr "la %1"
 
-#: extension.js:32 extension.js:44
+#: ../lib/fuzzyTime.js:22 ../lib/fuzzyTime.js:34
 msgid "twelve"
 msgstr "dek dua"
 
-#: extension.js:33
+#: ../lib/fuzzyTime.js:23
 msgid "one"
 msgstr "unua"
 
-#: extension.js:34
+#: ../lib/fuzzyTime.js:24
 msgid "two"
 msgstr "dua"
 
-#: extension.js:35
+#: ../lib/fuzzyTime.js:25
 msgid "three"
 msgstr "tria"
 
-#: extension.js:36
+#: ../lib/fuzzyTime.js:26
 msgid "four"
 msgstr "kvara"
 
-#: extension.js:37
+#: ../lib/fuzzyTime.js:27
 msgid "five"
 msgstr "kvina"
 
-#: extension.js:38
+#: ../lib/fuzzyTime.js:28
 msgid "six"
 msgstr "sesa"
 
-#: extension.js:39
+#: ../lib/fuzzyTime.js:29
 msgid "seven"
 msgstr "sepa"
 
-#: extension.js:40
+#: ../lib/fuzzyTime.js:30
 msgid "eight"
 msgstr "oka"
 
-#: extension.js:41
+#: ../lib/fuzzyTime.js:31
 msgid "nine"
 msgstr "naŭa"
 
-#: extension.js:42
+#: ../lib/fuzzyTime.js:32
 msgid "ten"
 msgstr "deka"
 
-#: extension.js:43
+#: ../lib/fuzzyTime.js:33
 msgid "eleven"
 msgstr "dek unua"

--- a/po/fr_FR.po
+++ b/po/fr_FR.po
@@ -1,4 +1,5 @@
-# French translations for Fuzzy Clock package.
+# French translations for Fuzzy Clock.
+# Traduction française pour Fuzzy Clock.
 # Copyright (C) 2020 Fuzzy Clock's COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # Marco DallaG <marco.dallagiacoma@gmail.com>, 2012.
@@ -7,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2012-09-15 20:37+0200\n"
-"PO-Revision-Date: 2012-12-18 21:50+0100\n"
+"POT-Creation-Date: 2020-11-26 11:26+0100\n"
+"PO-Revision-Date: 2020-11-26 11:26+0100\n"
 "Last-Translator: Philipp Kiemle <philipp.kiemle@gmail.com>\n"
 "Language-Team: French\n"
 "Language: fr\n"
@@ -17,103 +18,103 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: extension.js:16
-#, c-format
+#: ../lib/fuzzyTime.js:6
+#, javascript-format
 msgid "%0 o'clock"
 msgstr "%0 heures"
 
-#: extension.js:17
+#: ../lib/fuzzyTime.js:7
 msgid "five past %0"
 msgstr "%0 heures cinq"
 
-#: extension.js:18
+#: ../lib/fuzzyTime.js:8
 msgid "ten past %0"
 msgstr "%0 heures dix"
 
-#: extension.js:19
+#: ../lib/fuzzyTime.js:9
 msgid "quarter past %0"
 msgstr "%0 heures et quart"
 
-#: extension.js:20
+#: ../lib/fuzzyTime.js:10
 msgid "twenty past %0"
 msgstr "%0 heures et vingt"
 
-#: extension.js:21
+#: ../lib/fuzzyTime.js:11
 msgid "twenty five past %0"
 msgstr "%0 heures et vingt-cinq"
 
-#: extension.js:22
+#: ../lib/fuzzyTime.js:12
 msgid "half past %0"
 msgstr "%0 heures et demi"
 
-#: extension.js:23
+#: ../lib/fuzzyTime.js:13
 msgid "twenty five to %1"
 msgstr "%1 heures moins vingt-cinq"
 
-#: extension.js:24
+#: ../lib/fuzzyTime.js:14
 msgid "twenty to %1"
 msgstr "%1 heures moins vingt"
 
-#: extension.js:25
+#: ../lib/fuzzyTime.js:15
 msgid "quarter to %1"
 msgstr "%1 heures moins le quart"
 
-#: extension.js:26
+#: ../lib/fuzzyTime.js:16
 msgid "ten to %1"
 msgstr "%1 heures moins dix"
 
-#: extension.js:27
+#: ../lib/fuzzyTime.js:17
 msgid "five to %1"
 msgstr "%1 heures moins cinq"
 
-#: extension.js:28
+#: ../lib/fuzzyTime.js:18
 msgid "%1 o'clock"
 msgstr "%1 heures"
 
-#: extension.js:32 extension.js:44
+#: ../lib/fuzzyTime.js:22 ../lib/fuzzyTime.js:34
 msgid "twelve"
 msgstr "douze"
 
-#: extension.js:33
+#: ../lib/fuzzyTime.js:23
 msgid "one"
 msgstr "une"
 
-#: extension.js:34
+#: ../lib/fuzzyTime.js:24
 msgid "two"
 msgstr "deux"
 
-#: extension.js:35
+#: ../lib/fuzzyTime.js:25
 msgid "three"
 msgstr "trois"
 
-#: extension.js:36
+#: ../lib/fuzzyTime.js:26
 msgid "four"
 msgstr "quatre"
 
-#: extension.js:37
+#: ../lib/fuzzyTime.js:27
 msgid "five"
 msgstr "cinq"
 
-#: extension.js:38
+#: ../lib/fuzzyTime.js:28
 msgid "six"
 msgstr "six"
 
-#: extension.js:39
+#: ../lib/fuzzyTime.js:29
 msgid "seven"
 msgstr "sept"
 
-#: extension.js:40
+#: ../lib/fuzzyTime.js:30
 msgid "eight"
 msgstr "huit"
 
-#: extension.js:41
+#: ../lib/fuzzyTime.js:31
 msgid "nine"
 msgstr "neuf"
 
-#: extension.js:42
+#: ../lib/fuzzyTime.js:32
 msgid "ten"
 msgstr "dix"
 
-#: extension.js:43
+#: ../lib/fuzzyTime.js:33
 msgid "eleven"
 msgstr "onze"

--- a/po/it_IT.po
+++ b/po/it_IT.po
@@ -1,120 +1,120 @@
-# Italian translations for Fuzzy Clock package
-# Traduzioni italiane per il pacchetto Fuzzy Clock..
-# Copyright (C) 2012 Marco Dallagiacoma
+# Italian translations for Fuzzy Clock.
+# Traduzioni italiane per il pacchetto Fuzzy Clock.
+# Copyright (C) 2020 Marco Dallagiacoma
 # This file is distributed under the same license as the Fuzzy Clock package.
 # Marco Dallagiacoma <marco.dallagiacoma@gmail.com>, 2012.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
+"Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2012-09-15 20:37+0200\n"
-"PO-Revision-Date: 2012-09-15 20:41+0200\n"
-"Last-Translator: Marco DallaG <marco.dallagiacoma@gmail.com>\n"
-"Language-Team: Italian\n"
-"Language: it\n"
+"POT-Creation-Date: 2020-11-26 11:26+0100\n"
+"PO-Revision-Date: 2020-11-26 11:26+0100\n"
+"Last-Translator: Philipp Kiemle <philipp.kiemle@gmail.com>\n"
+"Language-Team: Italian - Italy\n"
+"Language: it-IT\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: extension.js:16
-#, c-format
+#: ../lib/fuzzyTime.js:6
+#, javascript-format
 msgid "%0 o'clock"
 msgstr "%0 in punto"
 
-#: extension.js:17
+#: ../lib/fuzzyTime.js:7
 msgid "five past %0"
 msgstr "%0 e cinque"
 
-#: extension.js:18
+#: ../lib/fuzzyTime.js:8
 msgid "ten past %0"
 msgstr "%0 e dieci"
 
-#: extension.js:19
+#: ../lib/fuzzyTime.js:9
 msgid "quarter past %0"
 msgstr "%0 e un quarto"
 
-#: extension.js:20
+#: ../lib/fuzzyTime.js:10
 msgid "twenty past %0"
 msgstr "%0 e venti"
 
-#: extension.js:21
+#: ../lib/fuzzyTime.js:11
 msgid "twenty five past %0"
 msgstr "%0 e venticinque"
 
-#: extension.js:22
+#: ../lib/fuzzyTime.js:12
 msgid "half past %0"
 msgstr "%0 e mezza"
 
-#: extension.js:23
+#: ../lib/fuzzyTime.js:13
 msgid "twenty five to %1"
 msgstr "%1 meno venticinque"
 
-#: extension.js:24
+#: ../lib/fuzzyTime.js:14
 msgid "twenty to %1"
 msgstr "%1 meno venti"
 
-#: extension.js:25
+#: ../lib/fuzzyTime.js:15
 msgid "quarter to %1"
 msgstr "%1 meno un quarto"
 
-#: extension.js:26
+#: ../lib/fuzzyTime.js:16
 msgid "ten to %1"
 msgstr "%1 meno dieci"
 
-#: extension.js:27
+#: ../lib/fuzzyTime.js:17
 msgid "five to %1"
 msgstr "%1 meno cinque"
 
-#: extension.js:28
+#: ../lib/fuzzyTime.js:18
 msgid "%1 o'clock"
 msgstr "%1 in punto"
 
-#: extension.js:32 extension.js:44
+#: ../lib/fuzzyTime.js:22 ../lib/fuzzyTime.js:34
 msgid "twelve"
 msgstr "dodici"
 
-#: extension.js:33
+#: ../lib/fuzzyTime.js:23
 msgid "one"
 msgstr "una"
 
-#: extension.js:34
+#: ../lib/fuzzyTime.js:24
 msgid "two"
 msgstr "due"
 
-#: extension.js:35
+#: ../lib/fuzzyTime.js:25
 msgid "three"
 msgstr "tre"
 
-#: extension.js:36
+#: ../lib/fuzzyTime.js:26
 msgid "four"
 msgstr "quattro"
 
-#: extension.js:37
+#: ../lib/fuzzyTime.js:27
 msgid "five"
 msgstr "cinque"
 
-#: extension.js:38
+#: ../lib/fuzzyTime.js:28
 msgid "six"
 msgstr "sei"
 
-#: extension.js:39
+#: ../lib/fuzzyTime.js:29
 msgid "seven"
 msgstr "sette"
 
-#: extension.js:40
+#: ../lib/fuzzyTime.js:30
 msgid "eight"
 msgstr "otto"
 
-#: extension.js:41
+#: ../lib/fuzzyTime.js:31
 msgid "nine"
 msgstr "nove"
 
-#: extension.js:42
+#: ../lib/fuzzyTime.js:32
 msgid "ten"
 msgstr "dieci"
 
-#: extension.js:43
+#: ../lib/fuzzyTime.js:33
 msgid "eleven"
 msgstr "undici"

--- a/po/messages.pot
+++ b/po/messages.pot
@@ -1,119 +1,118 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
+# Copyright (C) YEAR Marco Dallagiacoma
+# This file is distributed under the same license as the Fuzzy Clock package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
+"Project-Id-Version: Fuzzy Clock\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2012-09-15 20:37+0200\n"
+"POT-Creation-Date: 2020-11-26 12:23+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: extension.js:16
-#, c-format
+#: ../lib/fuzzyTime.js:6
+#, javascript-format
 msgid "%0 o'clock"
 msgstr ""
 
-#: extension.js:17
+#: ../lib/fuzzyTime.js:7
 msgid "five past %0"
 msgstr ""
 
-#: extension.js:18
+#: ../lib/fuzzyTime.js:8
 msgid "ten past %0"
 msgstr ""
 
-#: extension.js:19
+#: ../lib/fuzzyTime.js:9
 msgid "quarter past %0"
 msgstr ""
 
-#: extension.js:20
+#: ../lib/fuzzyTime.js:10
 msgid "twenty past %0"
 msgstr ""
 
-#: extension.js:21
+#: ../lib/fuzzyTime.js:11
 msgid "twenty five past %0"
 msgstr ""
 
-#: extension.js:22
+#: ../lib/fuzzyTime.js:12
 msgid "half past %0"
 msgstr ""
 
-#: extension.js:23
+#: ../lib/fuzzyTime.js:13
 msgid "twenty five to %1"
 msgstr ""
 
-#: extension.js:24
+#: ../lib/fuzzyTime.js:14
 msgid "twenty to %1"
 msgstr ""
 
-#: extension.js:25
+#: ../lib/fuzzyTime.js:15
 msgid "quarter to %1"
 msgstr ""
 
-#: extension.js:26
+#: ../lib/fuzzyTime.js:16
 msgid "ten to %1"
 msgstr ""
 
-#: extension.js:27
+#: ../lib/fuzzyTime.js:17
 msgid "five to %1"
 msgstr ""
 
-#: extension.js:28
+#: ../lib/fuzzyTime.js:18
 msgid "%1 o'clock"
 msgstr ""
 
-#: extension.js:32 extension.js:44
+#: ../lib/fuzzyTime.js:22 ../lib/fuzzyTime.js:34
 msgid "twelve"
 msgstr ""
 
-#: extension.js:33
+#: ../lib/fuzzyTime.js:23
 msgid "one"
 msgstr ""
 
-#: extension.js:34
+#: ../lib/fuzzyTime.js:24
 msgid "two"
 msgstr ""
 
-#: extension.js:35
+#: ../lib/fuzzyTime.js:25
 msgid "three"
 msgstr ""
 
-#: extension.js:36
+#: ../lib/fuzzyTime.js:26
 msgid "four"
 msgstr ""
 
-#: extension.js:37
+#: ../lib/fuzzyTime.js:27
 msgid "five"
 msgstr ""
 
-#: extension.js:38
+#: ../lib/fuzzyTime.js:28
 msgid "six"
 msgstr ""
 
-#: extension.js:39
+#: ../lib/fuzzyTime.js:29
 msgid "seven"
 msgstr ""
 
-#: extension.js:40
+#: ../lib/fuzzyTime.js:30
 msgid "eight"
 msgstr ""
 
-#: extension.js:41
+#: ../lib/fuzzyTime.js:31
 msgid "nine"
 msgstr ""
 
-#: extension.js:42
+#: ../lib/fuzzyTime.js:32
 msgid "ten"
 msgstr ""
 
-#: extension.js:43
+#: ../lib/fuzzyTime.js:33
 msgid "eleven"
 msgstr ""

--- a/scripts/update-po.sh
+++ b/scripts/update-po.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Scans the source code for any translatable string
+# and updates the po/messages.pot file accordingly.
+# The new strings are then merged with all existing translations.
+
+# Check if all necessary commands are available.
+if ! command -v xgettext &> /dev/null
+then
+  echo "ERROR: Could not find xgettext. On Ubuntu based systems, check if the gettext package is installed!"
+  exit 1
+elif ! command -v msgmerge &> /dev/null
+then
+  echo "ERROR: Could not find msgmerge. On Ubuntu based systems, check if the gettext package is installed!"
+  exit 1
+fi
+
+cd po || { echo "ERROR: Could not locate the 'po'directory."; exit 1; }
+
+# Update the template file with the strings from the source tree.
+# All preceeding comments starting with 'Translators' will be extracted as well.
+xgettext --from-code=UTF-8 --add-comments=Translators \
+         --package-name="Fuzzy Clock" --copyright-holder="Marco Dallagiacoma" \
+         --output=messages.pot ../lib/fuzzyTime.js || \
+{ echo "ERROR: Failed to extract translatable strings."; exit 1; } 
+
+# Then update all *.po files and check if they got fuzzy.
+NEED_CHECK=()
+for FILE in *.po
+do
+  # handle the case of no .po files
+  [[ -e "$FILE" ]] || { echo "ERROR: No .po files found, exiting."; exit 1; }
+  echo -n "Updating '$FILE' "
+  msgmerge -U "$FILE" messages.pot || \
+  { echo "ERROR: Failed to merge Strings into $FILE."; exit 1; }
+
+  if grep --silent "#, fuzzy" "$FILE"; then
+    NEED_CHECK+=("$FILE")
+  fi
+done
+
+# Check if 'messages.pot' got fuzzy
+if grep --silent "#, fuzzy" messages.pot; then
+    NEED_CHECK+=("messages.pot")
+  fi
+
+if [ ${#NEED_CHECK[@]} != 0 ]; then
+  echo "INFO: The following translation files need a look: ${NEED_CHECK[*]}"
+  echo "Make sure to remove the 'fuzzy' tag when updating the translation!" 
+fi
+
+echo "All done!"


### PR DESCRIPTION
This PR fixes #10.
By importing `gettext` in `fuzzyTime.js`, we can use the `_` alias to mark translatable Strings.
This enables us to use `xgettext` in a Script to check if new Strings need to be translated. I will incorporate this in #9 once this PR gets merged!
Run the script with `npm run update-po`.
It does definitely work, but when I do the `npm run test`, I get the following error:

```bash
$ npm run test
  ReferenceError: imports is not defined
```

It points specifically to the 2nd line in `fuzzyTime.js` - the import statement for `gettext`. As I said - the code runs perfectly, but this error makes it temporarily untestable. Do you know what's the issue here?